### PR TITLE
Include ROS headers as system headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ catkin_package(
 )
 
 include_directories(
+  SYSTEM
   ${catkin_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
  This allows users to compile with flag -Werror.